### PR TITLE
Apply new logger to prevent print log in production

### DIFF
--- a/lib/src/utils/debug_utils.dart
+++ b/lib/src/utils/debug_utils.dart
@@ -1,0 +1,16 @@
+class DebugUtils {
+
+  static final DebugUtils _instance = DebugUtils._internal();
+
+  DebugUtils._internal();
+
+  factory DebugUtils() {
+    return _instance;
+  }
+
+  bool get isDebugMode {
+    bool inDebugMode = false;
+    assert(inDebugMode = true);
+    return inDebugMode;
+  }
+}

--- a/lib/src/utils/logs.dart
+++ b/lib/src/utils/logs.dart
@@ -21,6 +21,8 @@
 * SOFTWARE.
 */
 
+import 'package:matrix_api_lite/src/utils/debug_utils.dart';
+
 import 'print_logs_native.dart' if (dart.library.html) 'print_logs_web.dart';
 
 enum Level {
@@ -51,14 +53,16 @@ class Logs {
   Logs._internal();
 
   void addLogEvent(LogEvent logEvent) {
+    if (!DebugUtils().isDebugMode) {
+      return;
+    }
     outputEvents.add(logEvent);
     if (logEvent.level.index <= level.index) {
       logEvent.printOut();
     }
   }
 
-  void wtf(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void wtf(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,
@@ -67,8 +71,7 @@ class Logs {
         ),
       );
 
-  void e(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void e(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,
@@ -77,8 +80,7 @@ class Logs {
         ),
       );
 
-  void w(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void w(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,
@@ -87,8 +89,7 @@ class Logs {
         ),
       );
 
-  void i(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void i(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,
@@ -97,8 +98,7 @@ class Logs {
         ),
       );
 
-  void d(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void d(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,
@@ -107,8 +107,7 @@ class Logs {
         ),
       );
 
-  void v(String title, [Object? exception, StackTrace? stackTrace]) =>
-      addLogEvent(
+  void v(String title, [Object? exception, StackTrace? stackTrace]) => addLogEvent(
         LogEvent(
           title,
           exception: exception,

--- a/lib/src/utils/print_logs_native.dart
+++ b/lib/src/utils/print_logs_native.dart
@@ -1,36 +1,33 @@
+import 'dart:developer';
+
 import 'package:matrix_api_lite/matrix_api_lite.dart';
 
 extension PrintLogs on LogEvent {
+
   void printOut() {
     var logsStr = title;
-    if (exception != null) {
-      logsStr += ' - ${exception.toString()}';
-    }
-    if (stackTrace != null) {
-      logsStr += '\n${stackTrace.toString()}';
-    }
     if (Logs().nativeColors) {
       switch (level) {
         case Level.wtf:
-          logsStr = '\x1B[31m!!!CRITICAL!!! $logsStr\x1B[0m';
+          log('\x1B[31m$logsStr', stackTrace: stackTrace, error: exception, level: 5, time: DateTime.now());
           break;
         case Level.error:
-          logsStr = '\x1B[31m$logsStr\x1B[0m';
+          logsStr = logsStr;
+          log('\x1B[31m $logsStr', stackTrace: stackTrace, error: exception, level: 4, time: DateTime.now());
           break;
         case Level.warning:
-          logsStr = '\x1B[33m$logsStr\x1B[0m';
+          log('\x1B[33m $logsStr', stackTrace: stackTrace, error: exception, level: 3, time: DateTime.now());
           break;
         case Level.info:
-          logsStr = '\x1B[32m$logsStr\x1B[0m';
+          log('\x1B[32m $logsStr', stackTrace: stackTrace, error: exception, level: 2, time: DateTime.now());
           break;
         case Level.debug:
-          logsStr = '\x1B[34m$logsStr\x1B[0m';
+          log('\x1B[34m $logsStr', stackTrace: stackTrace, error: exception, level: 1, time: DateTime.now());
           break;
         case Level.verbose:
+          log(' $logsStr', stackTrace: stackTrace, error: exception, level: 0, time: DateTime.now());
           break;
       }
     }
-    // ignore: avoid_print
-    print('[Matrix] $logsStr');
   }
 }


### PR DESCRIPTION
Because `assert` only work in debug mode, so make a method to check debugMode